### PR TITLE
Add Background Box to Text Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Shape element is simple-it draws a shape centered around a given point. Note
 | x  | The origin x coord of the shape |
 | y   | The origin y coord of the shape  |
 | points | An array containing objects with x and y parameters. This will form the body of the shape. Note that all coords in this array are relative to the x and y given as top level params. |
-| color | A hex color code, which determines the color of the shape |
+| color | Any color code that can be read by the [strokeStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeStyle#examples) param, which determines the color of the shape. This can be a hex code, rgba values or the name of a color like `aliceblue` |
 | fill | a boolean value, which determines if the shape is drawn as an outline (false) or a filled in shape (true) |
 | close | A boolean value (default true) which determines if the shape's path is closed before drawing, or left empty. Closing the path means a line will be drawn from the last point to the first point. |
 
@@ -102,8 +102,8 @@ Draws text to the screen at the given coordinates.
 | ----------- | ----------- |
 | x  | The origin x coord of the text |
 | y   | The origin y coord of the text |
-| color | the color for the text (default black) |
-| font | the font for the text (default 12px Arial) |
+| color | Any color code that can be read by the [fillStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle) which determines the color for the text (default `black` or `#000`). This can be a hex code, rgba values or the name of a color like `aliceblue` |
+| font | The font for the text (default 12px Arial) |
 
 ##### Children
 
@@ -267,7 +267,7 @@ The Line element draws a line of a specific color between two given points.
 | y | The origin y coord of the line  |
 | x2 | The destination x coord of the line |
 | y2 | The destination y coord of the line  |
-| color | A hex color code, which determines the color of the line |
+| color | Any color code that can be read by the [strokeStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeStyle#examples) param, which determines the color of the line. This can be a hex code, rgba values or the name of a color like `aliceblue` |
 
 ##### Example
 
@@ -298,7 +298,7 @@ The Rect element is just a wrapper around Shape that returns a rectangle drawn b
 | y | The second y coord of the rectangle |
 | x2 | The second x coord of the rectangle |
 | y2 | The second y coord of the rectangle |
-| color | A hex color code, which determines the color of the rectangle |
+| color | Any color code that can be read by the [strokeStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeStyle#examples) param, which determines the color of the rectangle. This can be a hex code, rgba values or the name of a color like `aliceblue` |
 | fill | Boolean, indicates if the rectangle should be filled or an outline |
 
 ##### Example
@@ -330,7 +330,7 @@ Draws a circle with a specific position and radius.
 | x | The x position of the circle center |
 | y | The y position of the circle center |
 | radius | The radius of the circle |
-| color | A hex color code, which determines the color of the circle |
+| color | Any color code that can be read by the [strokeStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeStyle#examples) param, which determines the color of the circle. This can be a hex code, rgba values or the name of a color like `aliceblue` |
 | fill | Boolean, indicates if the circle should be filled or an outline |
 
 ##### Example
@@ -364,7 +364,7 @@ Draws a semi-circle between two angles with a specific position and radius.
 | startAngle | The start angle in radians of the arc |
 | endAngle | The eng angle in radians of the arc |
 | sector | Boolean, indicates if the drawn shape should be a slice of pie (true) or just the outer part of the circle (false) |
-| color | A hex color code, which determines the color of the arc |
+| color | Any color code that can be read by the [strokeStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/strokeStyle#examples) param, which determines the color of the arc. This can be a hex code, rgba values or the name of a color like `aliceblue`c |
 | fill | Boolean, indicates if the arc should be filled or an outline |
 | closed | Boolean, determines if the arc should close its path (draw a line back to the start) or not |
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ Draws text to the screen at the given coordinates.
 | x  | The origin x coord of the text |
 | y   | The origin y coord of the text |
 | color | Any color code that can be read by the [fillStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle) which determines the color for the text (default `black` or `#000`). This can be a hex code, rgba values or the name of a color like `aliceblue` |
+| font | The font for the text (default 12px Arial) |
 | background | A boolean value to dictate whether the text should have a box background behind the text |
 | backgroundColor | Any color code that can be read by the [fillStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle) which determines the color for background of the text if `background` is true. The default value is `rgba(255, 255, 255, 0.5)` to allow background elements to be seen. This can be a hex code, rgba values or the name of a color like `aliceblue` |
-| font | The font for the text (default 12px Arial) |
+| padding | A value in pixels of how far the edge of the background box will be away from the text |
 
 ##### Children
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Draws text to the screen at the given coordinates.
 | x  | The origin x coord of the text |
 | y   | The origin y coord of the text |
 | color | Any color code that can be read by the [fillStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle) which determines the color for the text (default `black` or `#000`). This can be a hex code, rgba values or the name of a color like `aliceblue` |
+| background | A boolean value to dictate whether the text should have a box background behind the text |
+| backgroundColor | Any color code that can be read by the [fillStyle](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle) which determines the color for background of the text if `background` is true. The default value is `rgba(255, 255, 255, 0.5)` to allow background elements to be seen. This can be a hex code, rgba values or the name of a color like `aliceblue` |
 | font | The font for the text (default 12px Arial) |
 
 ##### Children

--- a/examples/basicExample/App/index.js
+++ b/examples/basicExample/App/index.js
@@ -63,6 +63,7 @@ const App = ({}) => {
 				y={80}
 				font="24px Times New Roman"
 				color="#00f"
+				background={true}
 			>
 				Big Text
 			</Text>

--- a/examples/basicExample/App/index.js
+++ b/examples/basicExample/App/index.js
@@ -64,6 +64,7 @@ const App = ({}) => {
 				font="24px Times New Roman"
 				color="#00f"
 				background={true}
+				backgroundColor="#FF0000"
 			>
 				Big Text
 			</Text>

--- a/examples/basicExample/Thing/index.js
+++ b/examples/basicExample/Thing/index.js
@@ -21,6 +21,10 @@ const Thing = () => {
 		<Text
 			x={205}
 			y={220}
+			color={"#FFF"}
+			background
+			backgroundColor="rgba(0,0,0,0.5)"
+			padding={50}
 		>
 			Blah {foo}
 		</Text>

--- a/examples/basicExample/Thing2.js
+++ b/examples/basicExample/Thing2.js
@@ -20,6 +20,7 @@ class Thing2 extends CanvasComponent {
             <Text
                 x={5 + x}
                 y={20 + y}
+                background
             >
                 Blah blah
             </Text>

--- a/examples/basicExample/Thing2.js
+++ b/examples/basicExample/Thing2.js
@@ -20,7 +20,6 @@ class Thing2 extends CanvasComponent {
             <Text
                 x={5 + x}
                 y={20 + y}
-                background
             >
                 Blah blah
             </Text>

--- a/src/main.js
+++ b/src/main.js
@@ -545,17 +545,17 @@ const Text = ({ children, x, y, color, font, backgroundColor, padding, backgroun
 		const text = children.join('');
 
 		if (background) {
-			const metrics = context.measureText(text);
-			const textWidth = metrics.width;
+			const textWidth = context.measureText(text).width;
 			const textHeight = parseInt(font, 10); // crude estimate of height
 
 			// Draw background box
 			context.fillStyle = backgroundColor;
-			context.fillRect(x - padding, y - textHeight, textWidth + padding * 2, textHeight + padding * 2);
+			context.fillRect(x - padding / 2, y - padding / 2 - textHeight, textWidth + padding, textHeight + padding);
 		}
 
 		// Draw the text
 		context.fillStyle = color;
+		context.textBaseline = "bottom";
 		context.fillText(text, x, y);
 
 		context.restore();

--- a/src/main.js
+++ b/src/main.js
@@ -517,7 +517,7 @@ class Canvas extends React.Component {
 Canvas.propTypes = canvasProps;
 Canvas.defaultProps = canvasDefaultProps;
 
-const Text = ({ children, x, y, color, font }) => {
+const Text = ({ children, x, y, color, font, backgroundColor, padding, background }) => {
 	const withContext = useWithContext();
 
 	return withContext((context) => {
@@ -527,13 +527,37 @@ const Text = ({ children, x, y, color, font }) => {
 		if (!font) {
 			font = "12px Arial";
 		}
-		context.save();
-		context.font = font;
-		context.fillStyle = color;
+		if (!padding) {
+			padding = 2;
+		}
+		if (!backgroundColor) {
+			backgroundColor = "rgba(255, 255, 255, 0.5)";
+		}
+		if (!background) { 
+			background = false;
+		}
 		if (!Array.isArray(children)) {
 			children = [children];
 		}
-		context.fillText(children.join(''), x, y);
+
+		context.save();
+		context.font = font;
+		const text = children.join('');
+
+		if (background) {
+			const metrics = context.measureText(text);
+			const textWidth = metrics.width;
+			const textHeight = parseInt(font, 10); // crude estimate of height
+
+			// Draw background box
+			context.fillStyle = backgroundColor;
+			context.fillRect(x - padding, y - textHeight, textWidth + padding * 2, textHeight + padding * 2);
+		}
+
+		// Draw the text
+		context.fillStyle = color;
+		context.fillText(text, x, y);
+
 		context.restore();
 	});
 }


### PR DESCRIPTION
I was using this library for a personal project and found it hard to see the text on some backgrounds. To solve that, I added a background box that centers the text in it. Hope this is a helpful addition. I not only updated the README with the props that I added for the `Text` component, but I also made the description for the `color` prop on many components match more accurately to what they are capable of.

Here's a screenshot of the basic example with those changes
![image](https://github.com/user-attachments/assets/ca34ad87-fc5f-4252-9b12-5df4510baa61)
